### PR TITLE
Update to latest version of k8s client in order to allow experiments on EKS clusters based of k8s 1.17.x

### DIFF
--- a/chaosengine-experiments/chaosengine-kubernetes/pom.xml
+++ b/chaosengine-experiments/chaosengine-kubernetes/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>7.0.0</version>
+            <version>9.0.2</version>
             <scope>compile</scope>
         </dependency>
         <!-- Kubernetes Dependencies -->


### PR DESCRIPTION
…