### PR TITLE
GCP Compute module updates

### DIFF
--- a/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/constants/GcpComputeConstants.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/constants/GcpComputeConstants.java
@@ -17,10 +17,11 @@
 
 package com.thales.chaos.constants;
 
-public class GcpConstants {
-    public static final String CREATED_BY_METADATA_KEY = "created-by";
-    public static final String MEMORYSTORE_LOCATION_WILDCARD = "-";
+public class GcpComputeConstants {
+    public static final String GCP_COMPUTE_INSTANCE_RUNNING = "RUNNING";
+    public static final String GCP_COMPUTE_INSTANCE_STOPPED = "STOPPED";
+    public static final String GCP_COMPUTE_INSTANCE_TERMINATED = "TERMINATED";
 
-    private GcpConstants () {
+    private GcpComputeConstants () {
     }
 }

--- a/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/platform/impl/GcpComputePlatform.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/platform/impl/GcpComputePlatform.java
@@ -56,6 +56,7 @@ import java.util.stream.Stream;
 import java.util.stream.StreamSupport;
 
 import static com.thales.chaos.constants.DataDogConstants.DATADOG_CONTAINER_KEY;
+import static com.thales.chaos.constants.GcpComputeConstants.GCP_COMPUTE_INSTANCE_RUNNING;
 import static com.thales.chaos.exception.enums.GcpComputeChaosErrorCode.GCP_COMPUTE_GENERIC_ERROR;
 import static com.thales.chaos.shellclient.ssh.GcpRuntimeSSHKey.CHAOS_USERNAME;
 import static java.util.Collections.emptyList;
@@ -79,7 +80,7 @@ public class GcpComputePlatform extends Platform implements SshBasedExperiment<G
     private Map<String, String> excludeFilter = Collections.emptyMap();
     @JsonProperty
     private Collection<SubnetUtils.SubnetInfo> routableCIDRBlocks = Collections.emptySet();
-    public static final String GCP_COMPUTE_RUNNING = "RUNNING";
+
 
     public void setRoutableCIDRBlocks (Collection<String> routableCIDRBlocks) {
         this.routableCIDRBlocks = routableCIDRBlocks.stream()
@@ -114,8 +115,8 @@ public class GcpComputePlatform extends Platform implements SshBasedExperiment<G
                                                    .flatMap(Collection::stream)
                                                    .map(Instance::getStatus)
                                                    .collect(Collectors.toList());
-        if (!statuses.stream().allMatch(GCP_COMPUTE_RUNNING::equals) || statuses.isEmpty()) {
-            if (statuses.stream().anyMatch(GCP_COMPUTE_RUNNING::equals)) {
+        if (!statuses.stream().allMatch(GCP_COMPUTE_INSTANCE_RUNNING::equals) || statuses.isEmpty()) {
+            if (statuses.stream().anyMatch(GCP_COMPUTE_INSTANCE_RUNNING::equals)) {
                 return PlatformHealth.DEGRADED;
             }
             return PlatformHealth.FAILED;

--- a/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/platform/impl/GcpComputePlatform.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/main/java/com/thales/chaos/platform/impl/GcpComputePlatform.java
@@ -114,7 +114,7 @@ public class GcpComputePlatform extends Platform implements SshBasedExperiment<G
                                                    .flatMap(Collection::stream)
                                                    .map(Instance::getStatus)
                                                    .collect(Collectors.toList());
-        if (!statuses.stream().allMatch(GCP_COMPUTE_RUNNING::equals)) {
+        if (!statuses.stream().allMatch(GCP_COMPUTE_RUNNING::equals) || statuses.isEmpty()) {
             if (statuses.stream().anyMatch(GCP_COMPUTE_RUNNING::equals)) {
                 return PlatformHealth.DEGRADED;
             }

--- a/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
@@ -971,16 +971,21 @@ public class GcpComputePlatformTest {
     @Test
     public void getPlatformHealth () {
         InstanceClient.AggregatedListInstancesPagedResponse response = mock(InstanceClient.AggregatedListInstancesPagedResponse.class);
-        Instance instance = Instance.newBuilder().setId("12345678901234567890").build();
+        Instance runningInstance = Instance.newBuilder().setStatus("RUNNING").setId("12345678901234567890").build();
+        Instance stoppedInstance = Instance.newBuilder().setStatus("STOPPED").setId("23456789123456789123").build();
         Iterable<InstancesScopedList> iterableInstances = List.of(InstancesScopedList.newBuilder()
-                                                                                     .addInstances(instance)
+                                                                                     .addInstances(runningInstance)
                                                                                      .build());
-        doReturn(iterableInstances).when(response).iterateAll();
-        doReturn(response).when(instanceClient).aggregatedListInstances(true, projectName);
-        assertEquals(PlatformHealth.OK, gcpComputePlatform.getPlatformHealth());
         doReturn(List.of()).when(response).iterateAll();
-        assertEquals(PlatformHealth.DEGRADED, gcpComputePlatform.getPlatformHealth());
-        doReturn(null).when(response).iterateAll();
+        doReturn(response).when(instanceClient).aggregatedListInstances(true, projectName);
+        assertEquals(PlatformHealth.FAILED, gcpComputePlatform.getPlatformHealth());
+        doReturn(iterableInstances).when(response).iterateAll();
+        assertEquals(PlatformHealth.OK, gcpComputePlatform.getPlatformHealth());
+        iterableInstances = List.of(InstancesScopedList.newBuilder()
+                                                       .addInstances(runningInstance)
+                                                       .addInstances(stoppedInstance)
+                                                       .build());
+        doReturn(iterableInstances).when(response).iterateAll();
         assertEquals(PlatformHealth.DEGRADED, gcpComputePlatform.getPlatformHealth());
     }
 

--- a/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
@@ -54,6 +54,7 @@ import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import static com.thales.chaos.constants.GcpComputeConstants.*;
 import static org.awaitility.Awaitility.await;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.*;
@@ -597,7 +598,7 @@ public class GcpComputePlatformTest {
                                                                       .setInstance(uniqueId)
                                                                       .build();
         Instance instance = mock(Instance.class);
-        doReturn("TERMINATED").when(instance).getStatus();
+        doReturn(GCP_COMPUTE_INSTANCE_TERMINATED).when(instance).getStatus();
         doReturn(instance).when(instanceClient).getInstance(instanceName);
         assertEquals(ContainerHealth.RUNNING_EXPERIMENT, gcpComputePlatform.isContainerRunning(container));
     }
@@ -616,7 +617,7 @@ public class GcpComputePlatformTest {
                                                                       .setInstance(uniqueId)
                                                                       .build();
         Instance instance = mock(Instance.class);
-        doReturn("STOPPED").when(instance).getStatus();
+        doReturn(GCP_COMPUTE_INSTANCE_STOPPED).when(instance).getStatus();
         doReturn(instance).when(instanceClient).getInstance(instanceName);
         assertEquals(ContainerHealth.RUNNING_EXPERIMENT, gcpComputePlatform.isContainerRunning(container));
     }
@@ -635,7 +636,7 @@ public class GcpComputePlatformTest {
                                                                       .setInstance(uniqueId)
                                                                       .build();
         Instance instance = mock(Instance.class);
-        doReturn("RUNNING").when(instance).getStatus();
+        doReturn(GCP_COMPUTE_INSTANCE_RUNNING).when(instance).getStatus();
         doReturn(instance).when(instanceClient).getInstance(instanceName);
         assertEquals(ContainerHealth.NORMAL, gcpComputePlatform.isContainerRunning(container));
     }
@@ -971,8 +972,14 @@ public class GcpComputePlatformTest {
     @Test
     public void getPlatformHealth () {
         InstanceClient.AggregatedListInstancesPagedResponse response = mock(InstanceClient.AggregatedListInstancesPagedResponse.class);
-        Instance runningInstance = Instance.newBuilder().setStatus("RUNNING").setId("12345678901234567890").build();
-        Instance stoppedInstance = Instance.newBuilder().setStatus("STOPPED").setId("23456789123456789123").build();
+        Instance runningInstance = Instance.newBuilder()
+                                           .setStatus(GCP_COMPUTE_INSTANCE_RUNNING)
+                                           .setId("12345678901234567890")
+                                           .build();
+        Instance stoppedInstance = Instance.newBuilder()
+                                           .setStatus(GCP_COMPUTE_INSTANCE_STOPPED)
+                                           .setId("23456789123456789123")
+                                           .build();
         Iterable<InstancesScopedList> iterableInstances = List.of(InstancesScopedList.newBuilder()
                                                                                      .addInstances(runningInstance)
                                                                                      .build());

--- a/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
+++ b/chaosengine-experiments/chaosengine-gcp-compute/src/test/java/com/thales/chaos/platform/impl/GcpComputePlatformTest.java
@@ -29,6 +29,7 @@ import com.thales.chaos.container.ContainerManager;
 import com.thales.chaos.container.enums.ContainerHealth;
 import com.thales.chaos.container.impl.GcpComputeInstanceContainer;
 import com.thales.chaos.exception.ChaosException;
+import com.thales.chaos.platform.enums.PlatformHealth;
 import com.thales.chaos.platform.enums.PlatformLevel;
 import com.thales.chaos.selfawareness.GcpComputeSelfAwareness;
 import com.thales.chaos.services.impl.GcpCredentialsMetadata;
@@ -965,6 +966,22 @@ public class GcpComputePlatformTest {
                 false);
         doThrow(exception).when(instanceClient).getInstance(instanceName);
         gcpComputePlatform.isContainerRecycled(container);
+    }
+
+    @Test
+    public void getPlatformHealth () {
+        InstanceClient.AggregatedListInstancesPagedResponse response = mock(InstanceClient.AggregatedListInstancesPagedResponse.class);
+        Instance instance = Instance.newBuilder().setId("12345678901234567890").build();
+        Iterable<InstancesScopedList> iterableInstances = List.of(InstancesScopedList.newBuilder()
+                                                                                     .addInstances(instance)
+                                                                                     .build());
+        doReturn(iterableInstances).when(response).iterateAll();
+        doReturn(response).when(instanceClient).aggregatedListInstances(true, projectName);
+        assertEquals(PlatformHealth.OK, gcpComputePlatform.getPlatformHealth());
+        doReturn(List.of()).when(response).iterateAll();
+        assertEquals(PlatformHealth.DEGRADED, gcpComputePlatform.getPlatformHealth());
+        doReturn(null).when(response).iterateAll();
+        assertEquals(PlatformHealth.DEGRADED, gcpComputePlatform.getPlatformHealth());
     }
 
     @Configuration

--- a/docs/markdown/Experiment_Modules/gcp_compute_experiments.md
+++ b/docs/markdown/Experiment_Modules/gcp_compute_experiments.md
@@ -6,7 +6,7 @@ The GCP Compute Engine module uses the Official [GCP Compute SDK for Java] from 
 
 ### Version
 
-All Google SDKs are included via the Google Cloud `libraries-bom` Maven package. The current version of the package is 3.0.0.
+All Google SDKs are included via the Google Cloud `libraries-bom` Maven package. The current version of the package is 10.1.0.
 
 ## Configuration
 


### PR DESCRIPTION
Implements missing `getPlatformHealth` method
