### PR TITLE
k8s extension - experiments on multiple namespaces

### DIFF
--- a/chaosengine-experiments/chaosengine-kubernetes/pom.xml
+++ b/chaosengine-experiments/chaosengine-kubernetes/pom.xml
@@ -15,7 +15,7 @@
         <dependency>
             <groupId>io.kubernetes</groupId>
             <artifactId>client-java</artifactId>
-            <version>9.0.2</version>
+            <version>10.0.0</version>
             <scope>compile</scope>
         </dependency>
         <!-- Kubernetes Dependencies -->

--- a/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/container/impl/KubernetesPodContainer.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/container/impl/KubernetesPodContainer.java
@@ -43,7 +43,7 @@ public class KubernetesPodContainer extends Container {
     private String podName;
     @Identifier(order = 2)
     private String namespace;
-    private Map<String, String> labels = new HashMap<>();
+    private final Map<String, String> labels = new HashMap<>();
     private boolean isBackedByController = false;
     private KubernetesPlatform kubernetesPlatform;
     @Identifier(order = 3)
@@ -52,7 +52,8 @@ public class KubernetesPodContainer extends Container {
     private String ownerName;
     private Collection<String> subcontainers = new HashSet<>();
     private String targetedSubcontainer;
-    private Callable<ContainerHealth> replicaSetRecovered = () -> kubernetesPlatform.replicaSetRecovered(this);
+    private final Callable<ContainerHealth> replicaSetRecovered = () -> kubernetesPlatform.replicaSetRecovered(this);
+    private String parentNode;
 
     private KubernetesPodContainer () {
         super();
@@ -80,6 +81,10 @@ public class KubernetesPodContainer extends Container {
 
     public String getOwnerName () {
         return ownerName;
+    }
+
+    public String getParentNode () {
+        return parentNode;
     }
 
     @Override
@@ -153,6 +158,7 @@ public class KubernetesPodContainer extends Container {
         private String ownerKind;
         private String ownerName;
         private Collection<String> subcontainers;
+        private String parentNode;
 
         private KubernetesPodContainerBuilder () {
         }
@@ -211,6 +217,11 @@ public class KubernetesPodContainer extends Container {
             return this;
         }
 
+        public KubernetesPodContainerBuilder withParentNode (String parentNode) {
+            this.parentNode = parentNode;
+            return this;
+        }
+
         public KubernetesPodContainer build () {
             KubernetesPodContainer kubernetesPodContainer = new KubernetesPodContainer();
             kubernetesPodContainer.uuid = this.uuid;
@@ -223,6 +234,7 @@ public class KubernetesPodContainer extends Container {
             kubernetesPodContainer.ownerKind = ControllerKind.mapFromString(this.ownerKind);
             kubernetesPodContainer.ownerName = ownerName;
             kubernetesPodContainer.subcontainers = this.subcontainers;
+            kubernetesPodContainer.parentNode = this.parentNode;
             try {
                 kubernetesPodContainer.setMappedDiagnosticContext();
                 kubernetesPodContainer.log.info("Created new Kubernetes Pod Container object");

--- a/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
@@ -139,7 +139,7 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
 
     @Override
     public PlatformHealth getPlatformHealth () {
-        if (namespaces.stream().map(this::canListPodsInNamespace).anyMatch(Boolean -> Boolean.equals(false))) {
+        if (namespaces.stream().map(this::canListPodsInNamespace).anyMatch(canList -> canList.equals(false))) {
             return PlatformHealth.FAILED;
         }
         if (namespaces.stream()

--- a/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
@@ -49,6 +49,7 @@ import java.util.stream.Collectors;
 
 import static com.thales.chaos.constants.DataDogConstants.DATADOG_CONTAINER_KEY;
 import static com.thales.chaos.exception.enums.KubernetesChaosErrorCode.K8S_API_ERROR;
+import static java.util.function.Predicate.not;
 import static net.logstash.logback.argument.StructuredArguments.v;
 
 @Component
@@ -59,12 +60,17 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
     private ContainerManager containerManager;
     @Autowired
     private final ApiClient apiClient;
-    private final String DEFAULT_NAMESPACE = "default";
+    static final String DEFAULT_NAMESPACE = "default";
     private Collection<String> namespaces = List.of(DEFAULT_NAMESPACE);
+
+    public Collection<String> getNamespaces () {
+        return namespaces;
+    }
 
     public void setNamespaces (String namespaces) {
         this.namespaces = Optional.of(Arrays.stream(namespaces.split(","))
                                             .filter(Objects::nonNull)
+                                            .filter(not(String::isEmpty))
                                             .collect(Collectors.toList()))
                                   .filter(l -> !l.isEmpty())
                                   .orElse(List.of(DEFAULT_NAMESPACE));

--- a/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
@@ -59,7 +59,7 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
     private ContainerManager containerManager;
 
     @Autowired
-    private ApiClient apiClient;
+    private final ApiClient apiClient;
     private String namespace = "default";
 
     @Autowired
@@ -195,11 +195,11 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
                                               .withKubernetesPlatform(this)
                                               .isBackedByController(CollectionUtils.isNotEmpty(pod.getMetadata()
                                                                                                   .getOwnerReferences()))
-                                              .withOwnerKind(Optional.of(pod.getMetadata().getOwnerReferences())
+                                              .withOwnerKind(Optional.ofNullable(pod.getMetadata().getOwnerReferences())
                                                                      .flatMap(list -> list.stream().findFirst())
                                                                      .map(V1OwnerReference::getKind)
                                                                      .orElse(""))
-                                              .withOwnerName(Optional.of(pod.getMetadata().getOwnerReferences())
+                                              .withOwnerName(Optional.ofNullable(pod.getMetadata().getOwnerReferences())
                                                                      .flatMap(list -> list.stream().findFirst())
                                                                      .map(V1OwnerReference::getName)
                                                                      .orElse(""))

--- a/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/main/java/com/thales/chaos/platform/impl/KubernetesPlatform.java
@@ -61,6 +61,7 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
     @Autowired
     private final ApiClient apiClient;
     static final String DEFAULT_NAMESPACE = "default";
+    static final String UNKNOWN_PARENT_NODE = "UNKNOWN";
     private Collection<String> namespaces = List.of(DEFAULT_NAMESPACE);
 
     public Collection<String> getNamespaces () {
@@ -223,6 +224,8 @@ public class KubernetesPlatform extends Platform implements ShellBasedExperiment
                                                                          .flatMap(Collection::stream)
                                                                          .map(V1Container::getName)
                                                                          .collect(Collectors.toList()))
+                                              .withParentNode(Optional.ofNullable(pod.getSpec().getNodeName())
+                                                                      .orElse(UNKNOWN_PARENT_NODE))
                                               .build();
             log.info("Found new Kubernetes Pod Container {}", v(DATADOG_CONTAINER_KEY, container));
             containerManager.offer(container);

--- a/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
@@ -506,8 +506,9 @@ public class KubernetesPlatformTest {
     }
 
     private static V1PodList getV1PodList (boolean isBackedByController, int numberOfPods) {
-        List<V1OwnerReference> ownerReferences = new ArrayList<>();
+        List<V1OwnerReference> ownerReferences = null;
         if (isBackedByController) {
+            ownerReferences = new ArrayList<>();
             ownerReferences.add(new V1OwnerReferenceBuilder().withNewController("mycontroller").build());
         }
         V1ObjectMeta metadata = new V1ObjectMetaBuilder().withUid(randomUUID().toString())
@@ -966,7 +967,7 @@ public class KubernetesPlatformTest {
     }
 
     private class TestProcess extends Process {
-        private InputStream is;
+        private final InputStream is;
 
         public TestProcess (InputStream is) {
             this.is = is;

--- a/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
@@ -34,6 +34,7 @@ import io.kubernetes.client.openapi.apis.CoreV1Api;
 import io.kubernetes.client.openapi.models.*;
 import junit.framework.TestCase;
 import org.apache.http.HttpStatus;
+import org.hamcrest.collection.IsIterableContainingInAnyOrder;
 import org.joda.time.DateTime;
 import org.junit.Assert;
 import org.junit.Before;
@@ -923,7 +924,18 @@ public class KubernetesPlatformTest {
     public void testGetConnectedShellClient () throws IOException, ApiException {
         KubernetesPodContainer kubernetesPodContainer = mock(KubernetesPodContainer.class);
         platform.getConnectedShellClient(kubernetesPodContainer);
+    }
 
+    @Test
+    public void testSetNamespaces () {
+        assertThat(platform.getNamespaces(),
+                IsIterableContainingInAnyOrder.containsInAnyOrder(KubernetesPlatform.DEFAULT_NAMESPACE));
+        platform.setNamespaces("");
+        assertThat(platform.getNamespaces(),
+                IsIterableContainingInAnyOrder.containsInAnyOrder(KubernetesPlatform.DEFAULT_NAMESPACE));
+        platform.setNamespaces("default,application");
+        assertThat(platform.getNamespaces(),
+                IsIterableContainingInAnyOrder.containsInAnyOrder("default", "application"));
     }
 
     @Configuration

--- a/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
@@ -928,8 +928,6 @@ public class KubernetesPlatformTest {
 
     @Test
     public void testSetNamespaces () {
-        assertThat(platform.getNamespaces(),
-                IsIterableContainingInAnyOrder.containsInAnyOrder(KubernetesPlatform.DEFAULT_NAMESPACE));
         platform.setNamespaces("");
         assertThat(platform.getNamespaces(),
                 IsIterableContainingInAnyOrder.containsInAnyOrder(KubernetesPlatform.DEFAULT_NAMESPACE));

--- a/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
@@ -79,22 +79,29 @@ public class KubernetesPlatformTest {
     @Mock
     private AppsV1Api appsV1Api;
 
-    @Before
-    public void setUp () {
-        doReturn(coreApi).when(platform).getCoreApi();
-        doReturn(coreV1Api).when(platform).getCoreV1Api();
-        doReturn(appsV1Api).when(platform).getAppsV1Api();
-        platform.setNamespace(NAMESPACE_NAME);
+    private static V1PodList getV1PodList (boolean isBackedByController, int numberOfPods) {
+        List<V1OwnerReference> ownerReferences = null;
+        if (isBackedByController) {
+            ownerReferences = new ArrayList<>();
+            ownerReferences.add(new V1OwnerReferenceBuilder().withNewController("mycontroller").build());
+        }
+        V1ObjectMeta metadata = new V1ObjectMetaBuilder().withUid(randomUUID().toString())
+                                                         .withName(POD_NAME)
+                                                         .withNamespace(NAMESPACE_NAME)
+                                                         .withLabels(new HashMap<>())
+                                                         .withOwnerReferences(ownerReferences)
+                                                         .build();
+        V1Pod pod = new V1Pod();
+        pod.setMetadata(metadata);
+        pod.setSpec(new V1PodSpec().containers(Collections.singletonList(new V1Container().name(randomUUID().toString()))));
+        V1PodList list = new V1PodList();
+        for (int i = 0; i < numberOfPods; i++) list.addItemsItem(pod);
+        return list;
     }
 
     @Test
     public void testPodWithoutOwnerCannotBeTested () throws Exception {
-        when(coreV1Api.listNamespacedPod(anyString(),
-                anyString(),
-                anyBoolean(),
-                anyString(),
-                anyString(),
-                anyString(),
+        when(coreV1Api.listNamespacedPod(anyString(), anyString(), anyBoolean(), anyString(), anyString(), anyString(),
                 anyInt(),
                 anyString(),
                 anyInt(),
@@ -139,31 +146,14 @@ public class KubernetesPlatformTest {
                 anyString(),
                 anyInt(),
                 anyBoolean())).thenThrow(new ApiException());
-        assertEquals("Error while checking container presence",
-                ContainerHealth.RUNNING_EXPERIMENT,
-                platform.checkHealth((KubernetesPodContainer) platform.getRoster().get(0)));
     }
 
-    @Test
-    public void testPodExists () throws ApiException {
-        V1PodList v1PodList = getV1PodList(true);
-        V1Pod pod = v1PodList.getItems().get(0);
-        KubernetesPodContainer kubernetesPodContainer = platform.fromKubernetesAPIPod(pod);
-        when(coreV1Api.listNamespacedPod(anyString(),
-                anyString(),
-                anyBoolean(),
-                anyString(),
-                anyString(),
-                anyString(),
-                anyInt(),
-                anyString(),
-                anyInt(),
-                anyBoolean())).thenReturn(v1PodList)
-                              .thenReturn(new V1PodList())
-                              .thenThrow(new ApiException(new IOException()));
-        assertTrue("POD exists", platform.podExists(kubernetesPodContainer).orElseThrow());
-        assertFalse("POD does not exist", platform.podExists(kubernetesPodContainer).orElseThrow());
-        assertTrue("IO Exception", platform.podExists(kubernetesPodContainer).isEmpty());
+    @Before
+    public void setUp () {
+        doReturn(coreApi).when(platform).getCoreApi();
+        doReturn(coreV1Api).when(platform).getCoreV1Api();
+        doReturn(appsV1Api).when(platform).getAppsV1Api();
+        platform.setNamespaces(NAMESPACE_NAME);
     }
 
     @Test
@@ -365,7 +355,10 @@ public class KubernetesPlatformTest {
     }
 
     @Test
-    public void testPlatformHealthNotAvailable () throws ApiException {
+    public void testPodExists () throws ApiException {
+        V1PodList v1PodList = getV1PodList(true);
+        V1Pod pod = v1PodList.getItems().get(0);
+        KubernetesPodContainer kubernetesPodContainer = platform.fromKubernetesAPIPod(pod);
         when(coreV1Api.listNamespacedPod(anyString(),
                 anyString(),
                 anyBoolean(),
@@ -375,35 +368,12 @@ public class KubernetesPlatformTest {
                 anyInt(),
                 anyString(),
                 anyInt(),
-                anyBoolean())).thenThrow(new ApiException());
-        assertEquals(PlatformHealth.FAILED, platform.getPlatformHealth());
-    }
-
-    @Test
-    public void testContainerHealthDoesNotExist () throws ApiException {
-        V1PodList list = new V1PodList();
-        V1Pod pod = mock(V1Pod.class);
-        V1ObjectMeta metadata = mock(V1ObjectMeta.class);
-        V1PodSpec spec = mock(V1PodSpec.class);
-        when(metadata.getUid()).thenReturn(randomUUID().toString());
-        when(pod.getMetadata()).thenReturn(metadata);
-        when(pod.getSpec()).thenReturn(spec);
-        list.addItemsItem(pod);
-        KubernetesPodContainer kubernetesPodContainer = KubernetesPodContainer.builder()
-                                                                              .withUUID(randomUUID().toString())
-                                                                              .withOwnerKind("")
-                                                                              .build();
-        when(coreV1Api.listNamespacedPod(anyString(),
-                anyString(),
-                anyBoolean(),
-                anyString(),
-                anyString(),
-                anyString(),
-                anyInt(),
-                anyString(),
-                anyInt(),
-                anyBoolean())).thenReturn(list);
-        assertEquals(ContainerHealth.DOES_NOT_EXIST, platform.checkHealth(kubernetesPodContainer));
+                anyBoolean())).thenReturn(v1PodList)
+                              .thenReturn(new V1PodList())
+                              .thenThrow(new ApiException(new IOException()));
+        assertTrue("POD exists", platform.podExists(kubernetesPodContainer));
+        assertFalse("POD does not exist", platform.podExists(kubernetesPodContainer));
+        assertFalse("IO Exception", platform.podExists(kubernetesPodContainer));
     }
 
     @Test
@@ -505,29 +475,32 @@ public class KubernetesPlatformTest {
                 platform.checkHealth((KubernetesPodContainer) platform.getRoster().get(0)));
     }
 
-    private static V1PodList getV1PodList (boolean isBackedByController, int numberOfPods) {
-        List<V1OwnerReference> ownerReferences = null;
-        if (isBackedByController) {
-            ownerReferences = new ArrayList<>();
-            ownerReferences.add(new V1OwnerReferenceBuilder().withNewController("mycontroller").build());
-        }
-        V1ObjectMeta metadata = new V1ObjectMetaBuilder().withUid(randomUUID().toString())
-                                                         .withName(POD_NAME)
-                                                         .withNamespace(NAMESPACE_NAME)
-                                                         .withLabels(new HashMap<>())
-                                                         .withOwnerReferences(ownerReferences)
-                                                         .build();
-        V1Pod pod = new V1Pod();
-        pod.setMetadata(metadata);
-        pod.setSpec(new V1PodSpec().containers(Collections.singletonList(new V1Container().name(randomUUID().toString()))));
-        V1PodList list = new V1PodList();
-        for (int i = 0; i < numberOfPods; i++) list.addItemsItem(pod);
-        return list;
-    }
-
     @Test
-    public void testGetNamespace () {
-        assertEquals("mynamespace", platform.getNamespace());
+    public void testContainerHealthDoesNotExist () throws ApiException {
+        V1PodList list = new V1PodList();
+        V1Pod pod = mock(V1Pod.class);
+        V1ObjectMeta metadata = mock(V1ObjectMeta.class);
+        V1PodSpec spec = mock(V1PodSpec.class);
+        when(metadata.getUid()).thenReturn(randomUUID().toString());
+        when(pod.getMetadata()).thenReturn(metadata);
+        when(pod.getSpec()).thenReturn(spec);
+        list.addItemsItem(pod);
+        KubernetesPodContainer kubernetesPodContainer = KubernetesPodContainer.builder()
+                                                                              .withNamespace(NAMESPACE_NAME)
+                                                                              .withUUID(randomUUID().toString())
+                                                                              .withOwnerKind("")
+                                                                              .build();
+        when(coreV1Api.listNamespacedPod(anyString(),
+                anyString(),
+                anyBoolean(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                anyString(),
+                anyInt(),
+                anyBoolean())).thenReturn(list);
+        assertEquals(ContainerHealth.DOES_NOT_EXIST, platform.checkHealth(kubernetesPodContainer));
     }
 
     private static V1PodList getV1PodList (boolean isBackedByController) {
@@ -848,6 +821,7 @@ public class KubernetesPlatformTest {
         String uid = randomUUID().toString();
         String containerName = randomUUID().toString();
         KubernetesPodContainer kubernetesPodContainer = spy(KubernetesPodContainer.builder()
+                                                                                  .withNamespace(NAMESPACE_NAME)
                                                                                   .withUUID(uid)
                                                                                   .withSubcontainers(List.of(
                                                                                           containerName))
@@ -923,7 +897,7 @@ public class KubernetesPlatformTest {
                                                                               .withOwnerKind(REPLICA_SET.toString())
                                                                               .withSubcontainers(Set.of(subContainer))
                                                                               .build();
-        doReturn(Optional.of(Boolean.TRUE)).when(platform).podExists(kubernetesPodContainer);
+        doReturn(true).when(platform).podExists(kubernetesPodContainer);
         doThrow(new ApiException()).when(coreV1Api).readNamespacedPodStatus(any(), any(), any());
         platform.isContainerRecycled(kubernetesPodContainer);
     }

--- a/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
+++ b/chaosengine-experiments/chaosengine-kubernetes/src/test/java/com/thales/chaos/platform/impl/KubernetesPlatformTest.java
@@ -189,6 +189,21 @@ public class KubernetesPlatformTest {
     }
 
     @Test
+    public void testPlatformHealthCannotListPods () throws ApiException {
+        when(coreV1Api.listNamespacedPod(anyString(),
+                anyString(),
+                anyBoolean(),
+                anyString(),
+                anyString(),
+                anyString(),
+                anyInt(),
+                anyString(),
+                anyInt(),
+                anyBoolean())).thenThrow(new ApiException());
+        assertEquals(PlatformHealth.FAILED, platform.getPlatformHealth());
+    }
+
+    @Test
     public void testPodWithOwnerCanBeTested () throws Exception {
         when(coreV1Api.listNamespacedPod(anyString(),
                 anyString(),

--- a/docs/markdown/Experiment_Modules/kubernetes_experiments.md
+++ b/docs/markdown/Experiment_Modules/kubernetes_experiments.md
@@ -14,7 +14,7 @@ The official Kubernetes Java Client is used to interact with the cluster.
 | | |
 | --- | --- |
 | Resource | <https://github.com/kubernetes-client/java> |
-| Version | 9.0.2 |
+| Version | 10.0.0 |
 |  Maven Repositories | <https://mvnrepository.com/artifact/io.kubernetes/client-java> |
 
 ## Configuration

--- a/docs/markdown/Experiment_Modules/kubernetes_experiments.md
+++ b/docs/markdown/Experiment_Modules/kubernetes_experiments.md
@@ -26,7 +26,7 @@ Environment variables that control how the Chaos Engine interacts with Kubernete
 | kubernetes | The presence of this key enables Kubernetes module. | N/A |  Yes |
 | kubernetes.url | Kubernetes server API url e.g. | None | Yes |
 | kubernetes.token | JWT token assigned to service account. You can get the value by running `kubectl describe secret name_of_your_secret` | None | Yes |
-| kubernetes.namespace | K8S namespace where experiments should be performed | `default` | Yes |
+| kubernetes.namespaces | Comma-separated list of namespaces where experiments should be performed | `default` | Yes |
 | kubernetes.debug | Enables debug log of Kubernetes java client | `false` | No |
 | kubernetes.validateSSL | Enables validation of sever side certificates | `false` | No |
 
@@ -36,6 +36,7 @@ A service account with a role binding needs to be created in order to access spe
 
 Please replace the {{namespace}} fillers with the appropriate values and apply to your cluster.
 
+### Experiments on single namespace
 **chaos-engine-service-account.yaml**
 
 ```yaml
@@ -110,7 +111,86 @@ subjects:
   namespace: {{namespace}}
 ```
 
-You can retrieve the token by running `kubectl describe secret chaos-engine -n {{namespace}}`
+You can retrieve the token by running `kubectl describe secret chaos-engine -n {{namespace}}`
+
+### Experiments on multiple namespaces
+
+When your experiment targets are located in multiple namespaces, 
+you need to bind roles allowing access to appropriate namespace to your service account.
+Or you can simply create a cluster role and binding by running below yaml.
+
+
+```yaml
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: chaos-engine-crole
+rules:
+- apiGroups:
+  - apps
+  resources:
+  - daemonsets
+  - daemonsets/status
+  - deployments
+  - deployments/status
+  - replicasets
+  - replicasets/status
+  - statefulsets
+  - statefulsets/status
+  verbs:
+  - get
+  - list
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - delete
+
+
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  - pods/status
+  - replicationcontrollers/status
+  verbs:
+  - get
+  - list
+
+- apiGroups:
+  - ""
+  resources:
+  - pods/exec
+  verbs:
+  - create
+  - get
+
+---
+
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: chaos-engine-rolebinding
+roleRef:
+  kind: ClusterRole
+  name: chaos-engine-crole
+  apiGroup: rbac.authorization.k8s.io
+subjects:
+- kind: ServiceAccount
+  name: chaos-engine-serviceaccount
+  namespace: {{namespace}}
+
+---
+
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: chaos-engine-serviceaccount
+  namespace: {{namespace}}
+
+```
+
 
 ### Verify Service Account Setting
 


### PR DESCRIPTION
Previous implementation allowed experiments in single namespace only. The PR is going to remove this limitation and allow experimentation on multiple namespaces in parallel.